### PR TITLE
revealmap regexp in cmd args

### DIFF
--- a/doc/wargus.6
+++ b/doc/wargus.6
@@ -7,16 +7,16 @@ for Stratagus, and shares most of its commandline arguments.
 .TP
 Wargus has specific command line arguments to start multiplayer games:
 .TP
-.B -c multiplayer -G server,numplayers=(number),map=(path-to-map)[,dedicated,race=(orc|human),player=(nick),fow=(1|0),revealmap=(0|1),resources=(low|medium|high),units=1]
+.B -c multiplayer -G server,numplayers=(number),map=(path-to-map)[,dedicated,race=(orc|human),player=(nick),fow=(1|0),reveal=(0|1),resources=(low|medium|high),units=1]
 These arguments start a multiplayer server. It will directly select the passed
 map and wait for numplayers players to join and become ready (including the
 server), before automatically starting the game. The numplayers and map
-arguments are required, the race, player nickname, fow (fog of war), revealmap,
-resources and units options are optional. Note that if there are spaces or
-other characters that must be escaped in the nickname or map path, you must
-escape them (or enclose the entire argument in quotes). If the dedicated option
-is passed, the server will itself only be an AI player, and wait for numplayers
-clients to connect (excluding the server).
+arguments are required, the race, player nickname, fow (Fog of war), reveal
+(Reveal map), resources and units options are optional. Note that if there are
+spaces or other characters that must be escaped in the nickname or map path,
+you must escape them (or enclose the entire argument in quotes). If the
+dedicated option is passed, the server will itself only be an AI player, and
+wait for numplayers clients to connect (excluding the server).
 .TP
 .B -c multiplayer -G client,ip=(server-ip)[,race=(orc|human),player=(nick)]
 These arguments start a multiplayer game as client. It will directly join the

--- a/scripts/menus/options.lua
+++ b/scripts/menus/options.lua
@@ -287,7 +287,7 @@ function RunPreferencesMenu()
   
   local fogOfWar
   if (not IsNetworkGame()) then
-	  fogOfWar = menu:addImageCheckBox(_("For of War"), 10, 10 + 18 * 12, offi, offi2, oni, oni2, function() end)
+	  fogOfWar = menu:addImageCheckBox(_("Fog of War"), 10, 10 + 18 * 12, offi, offi2, oni, oni2, function() end)
 	  fogOfWar:setActionCallback(
 		function()
 			SetFogOfWar(fogOfWar:isMarked())

--- a/scripts/multiplayer.lua
+++ b/scripts/multiplayer.lua
@@ -16,7 +16,7 @@ local function usage()
   print("\t[fow=(1|0)] -- only valid for server")
   print("\t[units=1] -- only valid for server (1 is for one peasant only)")
   print("\t[resources=(Low|Medium|High)] -- only valid for server")
-  print("\t[revealmap=(0|1)] -- only valid for server")
+  print("\t[reveal=(0|1)] -- only valid for server")
   print("\nAll options must be passed comma-separated. For example:")
   print("\twargus -c multiplayer -G server,race=human,map=islands.smp.gz,numplayers=2,resources=High,units=1")
   print("\t\t... will start a server that waits for one more player.")
@@ -45,7 +45,7 @@ else
   local nickname = string.match(ARGS,"player=([^,]+)")
   local numplayers = tonumber(string.match(ARGS,"numplayers=([^,]+)"))
   local fow = tonumber(string.match(ARGS,"fow=([^,]+)"))
-  local reveal = tonumber(string.match(ARGS,"revealmap=([^,]+)"))
+  local reveal = tonumber(string.match(ARGS,"reveal=([^,]+)"))
 
   if (nickname) then SetLocalPlayerName(nickname) end
 

--- a/scripts/spells.lua
+++ b/scripts/spells.lua
@@ -86,7 +86,7 @@ DefineSpell("spell-suicide-bomber", {
 
 DefineSpell("spell-suicide-bomber",
 	"showname", _("Demolish"), "manacost", 0, "target", "self", "range", 1,
-	"action", {{"demolish", "range", 1, "damage", 400},
+	"action", {{"demolish", "range", 2, "damage", 400},
 		{"spawn-missile", "missile", "missile-normal-spell",
 			"end-point",   {"base", "caster"}}},
 	"sound-when-cast", "explosion",

--- a/scripts/translate/ru_RU.po
+++ b/scripts/translate/ru_RU.po
@@ -1791,7 +1791,7 @@ msgid "Deselect in mines"
 msgstr "Снимать выдел. при добыче"
 
 #: /media/l_disk/programming/wwargus/wargus/scripts/menus/options.lua:290
-msgid "For of War"
+msgid "Fog of War"
 msgstr "Туман войны"
 
 #: /media/l_disk/programming/wwargus/wargus/scripts/menus/options.lua:299


### PR DESCRIPTION
'revealmap=' vs 'map=' has regexp issue in cmd line parser. 'revealmap' option renamed to 'reveal'
s/For of war/Fog of war/ typo