### PR TITLE
now if you have less than 4 attack peasants, you lose

### DIFF
--- a/campaigns/human/level10h_c.sms
+++ b/campaigns/human/level10h_c.sms
@@ -12,8 +12,13 @@ Briefing(
 
 Triggers = [[
 AddTrigger(
-  function() return IfRescuedNearUnit("this", ">=", 4, "unit-peasant", "unit-circle-of-power") end,
+  function() return IfRescuedNearUnit("this", ">=", 4, "unit-attack-peasant", "unit-circle-of-power") end,
   function() return ActionVictory() end)
+
+AddTrigger(
+  function() return GetPlayerData(4, "UnitTypesCount", "unit-attack-peasant") <= 3 and
+  GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-attack-peasant") <= 3 end,
+  function() return ActionDefeat() end)
 
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,


### PR DESCRIPTION
Btw, level10h.sms file of this mission must also be changed. The rescued peasants were regular peasants, and not attack peasants. Meaning they can build buildings and stuff. This was originally not this way.
And now, if player has less than 4 attack peasants, player automatically loses the game.
