### PR TITLE
Replacing ffmpeg2theora with ffmpeg

### DIFF
--- a/COPYING-3rd
+++ b/COPYING-3rd
@@ -13,13 +13,12 @@ cdda2wav:
 
 
 
-ffmpeg2theora:
+ffmpeg:
 
-  A simple converter to create Ogg Theora files.
-  With ffmpeg2theora you can convert any file that ffmpeg can decode to theora.
+  ffmpeg is a converter for various multimedia file formats. It is used in this project to convert audio and video files to theora (ogg/ogv)
 
-  This software use official build for Windows from http://v2v.cc/~j/ffmpeg2theora/ffmpeg2theora-0.28.exe
+  This software use official build for Windows from http://ffmpeg.zeranoe.com/builds/win32/static/ffmpeg-3.3.3-win32-static.zip
 
-  License: GNU GPL v3
-  Homepage: http://v2v.cc/~j/ffmpeg2theora/
+  License: GNU LGPL 2.1 (https://www.ffmpeg.org/legal.html)
+  Homepage: https://www.ffmpeg.org
 

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Homepage: https://github.com/Wargus/wargus
 Package: wargus
 Architecture: any
 Depends: ${stratagus:Depends}, ${misc:Depends}, ${shlibs:Depends}
-Pre-Depends: cdparanoia, ffmpeg2theora, xterm
+Pre-Depends: cdparanoia, ffmpeg, xterm
 Recommends: musescore-soundfont-gm
 Provides: stratagus-data
 Description: Warcraft II data game set for the Stratagus engine

--- a/doc/changelog
+++ b/doc/changelog
@@ -1,3 +1,5 @@
+2.4.3
+  - Switched from ffmpeg2theora to vanilla ffmpeg due to file import/conversion issues
 2.4.2
   - Add support for advertising and joining games on a metaserver
   - Allow selecting the number of AI players in multiplayer games

--- a/wargus.nsi
+++ b/wargus.nsi
@@ -96,7 +96,7 @@ ${redefine} VCREDISTREGKEY "SOFTWARE\WOW6432Node\Microsoft\VisualStudio\14.0\VC\
 ; Download and extract nessesary 3rd party programs
 !ifndef NO_DOWNLOAD
 !system 'powershell -Command "& {wget http://ffmpeg.zeranoe.com/builds/win32/static/ffmpeg-3.3.3-win32-static.zip -OutFile ffmpeg.zip}"'
-!system 'powershell -Command "& {unzip -o ffmpeg.zip bin\ffmpeg.exe}"'
+!system 'powershell -Command "& {unzip -o -j ffmpeg.zip "ffmpeg-3.3.3-win32-static/bin/ffmpeg.exe"}"'
 !system 'powershell -Command "& {wget http://smithii.com/files/cdrtools-2.01-bootcd.ru-w32.zip -OutFile cdrtools.zip}"'
 !system 'powershell -Command "& {unzip -o cdrtools.zip cdda2wav.exe}"'
 !system 'powershell -Command "& {wget http://ocmnet.com/saxguru/TimGM6mb.sf2 -OutFile TimGM6mb.sf2}"'

--- a/wargus.nsi
+++ b/wargus.nsi
@@ -96,7 +96,7 @@ ${redefine} VCREDISTREGKEY "SOFTWARE\WOW6432Node\Microsoft\VisualStudio\14.0\VC\
 ; Download and extract nessesary 3rd party programs
 !ifndef NO_DOWNLOAD
 !system 'powershell -Command "& {wget http://ffmpeg.zeranoe.com/builds/win32/static/ffmpeg-3.3.3-win32-static.zip -OutFile ffmpeg.zip}"'
-!system 'powershell -Command "& {unzip -o ffmpeg.zip ffmpeg.exe}"'
+!system 'powershell -Command "& {unzip -o ffmpeg.zip bin\ffmpeg.exe}"'
 !system 'powershell -Command "& {wget http://smithii.com/files/cdrtools-2.01-bootcd.ru-w32.zip -OutFile cdrtools.zip}"'
 !system 'powershell -Command "& {unzip -o cdrtools.zip cdda2wav.exe}"'
 !system 'powershell -Command "& {wget http://ocmnet.com/saxguru/TimGM6mb.sf2 -OutFile TimGM6mb.sf2}"'

--- a/wargus.nsi
+++ b/wargus.nsi
@@ -438,6 +438,7 @@ ${redefine} UPX_FLAGS "${UPX_FLAGS} -q"
 ;--------------------------------
 
 !ifndef NO_DOWNLOAD
+!delfile "ffmpeg.exe"
 !delfile "ffmpeg.zip"
 !delfile "cdda2wav.exe"
 !delfile "cdrtools.zip"

--- a/wargus.nsi
+++ b/wargus.nsi
@@ -69,7 +69,7 @@
 !system "powershell -Command $\"& {cp **\${PUDCONVERT} ${PUDCONVERT}}$\""
 
 !define CDDA2WAV "cdda2wav.exe"
-!define FFMPEG2THEORA "ffmpeg2theora.exe"
+!define FFMPEG "ffmpeg.exe"
 !define SF2BANK "TimGM6mb.sf2"
 !define VCREDIST "vc_redist.x86.exe"
 !define VCREDISTREGKEY "SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x86"
@@ -95,7 +95,7 @@ ${redefine} VCREDISTREGKEY "SOFTWARE\WOW6432Node\Microsoft\VisualStudio\14.0\VC\
 
 ; Download and extract nessesary 3rd party programs
 !ifndef NO_DOWNLOAD
-!system 'powershell -Command "& {wget http://v2v.cc/~j/ffmpeg2theora/ffmpeg2theora-0.28.exe -OutFile ffmpeg2theora.exe}"'
+!system 'powershell -Command "& {wget http://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-3.3.3-win32-static.zip -OutFile ffmpeg.zip}"'
 !system 'powershell -Command "& {wget http://smithii.com/files/cdrtools-2.01-bootcd.ru-w32.zip -OutFile cdrtools.zip}"'
 !system 'powershell -Command "& {unzip -o cdrtools.zip cdda2wav.exe}"'
 !system 'powershell -Command "& {wget http://ocmnet.com/saxguru/TimGM6mb.sf2 -OutFile TimGM6mb.sf2}"'
@@ -227,7 +227,7 @@ Section "-${NAME}"
 	File "${WARTOOL}"
 	File "${PUDCONVERT}"
 	File "${CDDA2WAV}"
-	File "${FFMPEG2THEORA}"
+	File "${FFMPEG}"
 
 	; -- XXX TODO: include Stratagus and dependencies some better way
 	File "stratagus.exe"
@@ -331,7 +331,7 @@ Section "un.${NAME}" Executable
 	Delete "$INSTDIR\${WARTOOL}"
 	Delete "$INSTDIR\${PUDCONVERT}"
 	Delete "$INSTDIR\${CDDA2WAV}"
-	Delete "$INSTDIR\${FFMPEG2THEORA}"
+	Delete "$INSTDIR\${FFMPEG}"
 	Delete "$INSTDIR\${UNINSTALL}"
 
 	IfFileExists "$INSTDIR\scripts\wc2-config.lua" 0 +2
@@ -437,7 +437,7 @@ ${redefine} UPX_FLAGS "${UPX_FLAGS} -q"
 ;--------------------------------
 
 !ifndef NO_DOWNLOAD
-!delfile "ffmpeg2theora.exe"
+!delfile "ffmpeg.zip"
 !delfile "cdda2wav.exe"
 !delfile "cdrtools.zip"
 !delfile "TimGM6mb.sf2"

--- a/wargus.nsi
+++ b/wargus.nsi
@@ -95,7 +95,7 @@ ${redefine} VCREDISTREGKEY "SOFTWARE\WOW6432Node\Microsoft\VisualStudio\14.0\VC\
 
 ; Download and extract nessesary 3rd party programs
 !ifndef NO_DOWNLOAD
-!system 'powershell -Command "& {wget http://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-3.3.3-win32-static.zip -OutFile ffmpeg.zip}"'
+!system 'powershell -Command "& {wget http://ffmpeg.zeranoe.com/builds/win32/static/ffmpeg-3.3.3-win32-static.zip -OutFile ffmpeg.zip}"'
 !system 'powershell -Command "& {wget http://smithii.com/files/cdrtools-2.01-bootcd.ru-w32.zip -OutFile cdrtools.zip}"'
 !system 'powershell -Command "& {unzip -o cdrtools.zip cdda2wav.exe}"'
 !system 'powershell -Command "& {wget http://ocmnet.com/saxguru/TimGM6mb.sf2 -OutFile TimGM6mb.sf2}"'

--- a/wargus.nsi
+++ b/wargus.nsi
@@ -96,6 +96,7 @@ ${redefine} VCREDISTREGKEY "SOFTWARE\WOW6432Node\Microsoft\VisualStudio\14.0\VC\
 ; Download and extract nessesary 3rd party programs
 !ifndef NO_DOWNLOAD
 !system 'powershell -Command "& {wget http://ffmpeg.zeranoe.com/builds/win32/static/ffmpeg-3.3.3-win32-static.zip -OutFile ffmpeg.zip}"'
+!system 'powershell -Command "& {unzip -o ffmpeg.zip ffmpeg.exe}"'
 !system 'powershell -Command "& {wget http://smithii.com/files/cdrtools-2.01-bootcd.ru-w32.zip -OutFile cdrtools.zip}"'
 !system 'powershell -Command "& {unzip -o cdrtools.zip cdda2wav.exe}"'
 !system 'powershell -Command "& {wget http://ocmnet.com/saxguru/TimGM6mb.sf2 -OutFile TimGM6mb.sf2}"'

--- a/wartool.cpp
+++ b/wartool.cpp
@@ -1912,13 +1912,13 @@ int ConvertMusic(void)
 		if (stat(buf, &st))
 			continue;
 
-		cmd = (char*) calloc(strlen("ffmpeg2theora --optimize \"") + strlen(buf) + strlen("\" -o \"") + strlen(buf) + strlen("\"") + 1, 1);
+		cmd = (char*) calloc(strlen("ffmpeg -y -i \"") + strlen(buf) + strlen("\" \"") + strlen(buf) + strlen("\"") + 1, 1);
 		if (!cmd) {
 			fprintf(stderr, "Memory error\n");
 			error("Memory error", "Could not allocate enough memory to read archive.");
 		}
 
-		sprintf(cmd, "ffmpeg2theora --optimize \"%s\" -o \"%s/%s/%s.ogg\"", buf, Dir, MUSIC_PATH, MusicNames[i]);
+		sprintf(cmd, "ffmpeg -y -i \"%s\" \"%s/%s/%s.ogg\"", buf, Dir, MUSIC_PATH, MusicNames[i]);
 
 		ret = system(cmd);
 
@@ -1926,7 +1926,7 @@ int ConvertMusic(void)
 		remove(buf);
 
 		if (ret != 0) {
-			printf("Can't convert wav sound %s to ogv format. Is ffmpeg2theora installed in PATH?\n", MusicNames[i]);
+			printf("Can't convert wav sound %s to ogg format. Is ffmpeg installed in PATH?\n", MusicNames[i]);
 			fflush(stdout);
 		}
 
@@ -1940,13 +1940,13 @@ int ConvertMusic(void)
 			if (stat(buf, &st))
 				continue;
 
-			cmd = (char*) calloc(strlen("ffmpeg2theora --optimize \"") + strlen(buf) + strlen("\" -o \"") + strlen(buf) + strlen("\"") + 1, 1);
+			cmd = (char*) calloc(strlen("ffmpeg -y -i \"") + strlen(buf) + strlen("\" \"") + strlen(buf) + strlen("\"") + 1, 1);
 			if (!cmd) {
 				fprintf(stderr, "Memory error\n");
 				error("Memory error", "Could not allocate enough memory to read archive.");
 			}
 
-			sprintf(cmd, "ffmpeg2theora --optimize \"%s\" -o \"%s/%s/%s.ogg\"", buf, Dir, MUSIC_PATH, BNEMusicNames[i]);
+			sprintf(cmd, "ffmpeg -y -i \"%s\" \"%s/%s/%s.ogg\"", buf, Dir, MUSIC_PATH, BNEMusicNames[i]);
 
 			ret = system(cmd);
 
@@ -1954,7 +1954,7 @@ int ConvertMusic(void)
 			remove(buf);
 
 			if (ret != 0) {
-				printf("Can't convert wav sound %s to ogv format. Is ffmpeg2theora installed in PATH?\n", BNEMusicNames[i]);
+				printf("Can't convert wav sound %s to ogg format. Is ffmpeg installed in PATH?\n", BNEMusicNames[i]);
 				fflush(stdout);
 			}
 
@@ -2005,13 +2005,13 @@ int ConvertVideo(const char* file, int video, bool justconvert = false)
 		fclose(f);
 	}
 
-	cmd = (char*) calloc(strlen("ffmpeg2theora --optimize \"") + strlen(buf) + strlen("\" -o \"") + strlen(buf) + strlen("\"") + 1, 1);
+	cmd = (char*) calloc(strlen("ffmpeg -y -i \"") + strlen(buf) + strlen("\" \"") + strlen(buf) + strlen("\"") + 1, 1);
 	if (!cmd) {
 		fprintf(stderr, "Memory error\n");
 		error("Memory error", "Could not allocate enough memory to read archive.");
 	}
 
-	sprintf(cmd, "ffmpeg2theora --optimize \"%s/%s.smk\" -o \"%s/%s.ogv\"", Dir, file, Dir, file);
+	sprintf(cmd, "ffmpeg -y -i \"%s/%s.smk\" \"%s/%s.ogv\"", Dir, file, Dir, file);
 
 	ret = system(cmd);
 
@@ -2021,7 +2021,7 @@ int ConvertVideo(const char* file, int video, bool justconvert = false)
 	if (ret != 0) {
 		sprintf(outputfile, "%s/%s.ogv", Dir, file);
 		unlink(outputfile);
-		printf("Can't convert video %s to ogv format. Is ffmpeg2theora installed in PATH?\n", file);
+		printf("Can't convert video %s to ogv format. Is ffmpeg installed in PATH?\n", file);
 		fflush(stdout);
 		return ret;
 	}


### PR DESCRIPTION
As requested by @timfel in #249 I created a pull request to replace ffmpeg2theora once and for all. The changes are untested and the push request should thereof be treated with caution. Especially the Windows part is expected to be broken (the ffmpeg.zip contains a subfolder bin instead of just the .exe).

The Linux part should work, but there seems to be an error with the video playback in wargus. The video is in grayscale and there is a misplaced colored layer on top of it. Any decent video player however can play the same ogv without any problems.

Can someone please test the changes and confirm if everything works as expected?