### PR TITLE
lowercase path for BNE export for linux

### DIFF
--- a/wartool.cpp
+++ b/wartool.cpp
@@ -2491,8 +2491,8 @@ int main(int argc, char** argv)
 	}
 
 	// Detect if CD is Mac/Dos, Expansion/Original/BNE, and language
-	sprintf(buf, "%s/SUPPORT/TOMES/TOME.1", ArchiveDir);
-	sprintf(filename, "%s/SUPPORT/TOMES/TOME.4", ArchiveDir);
+	sprintf(buf, "%s/support/tomes/tome.1", ArchiveDir);
+	sprintf(filename, "%s/support/tomes/tome.4", ArchiveDir);
 	if (!stat(buf, &st)) {
 		printf("Detected BNE CD\n");
 		fflush(stdout);


### PR DESCRIPTION
So I finally tested on my debian : the content of the BNE CD is also lowercase here. So I think it's safe to handle it all as lowercase (as windows doesn't care) 
And got the videos working with ffmpeg (I got some laggy video but at least got videos unlike ffmpeg2theora)
So we can close #241 