### PR TITLE
Fix SoundFont dependency on Debian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,9 +11,9 @@ Homepage: https://github.com/Wargus/wargus
 
 Package: wargus
 Architecture: any
-Depends: ${stratagus:Depends}, ${misc:Depends}, ${shlibs:Depends}
+Depends: ${stratagus:Depends}, ${misc:Depends}, ${shlibs:Depends},
+ timgm6mb-soundfont
 Pre-Depends: cdparanoia, ffmpeg, xterm
-Recommends: musescore-soundfont-gm
 Provides: stratagus-data
 Description: Warcraft II data game set for the Stratagus engine
  Wargus can be used to play Warcraft II from Blizzard Entertainment.


### PR DESCRIPTION
This update adds a dependency on `timgm6mb-soundfont` to have music on by
default when playing Warcraft II.

Fixes #256

Please note I couldn't test the build locally because I couldn't find the latest tarball for Wargus 2.4.2.