### PR TITLE
Fixed values of game type menu list items. …

### DIFF
--- a/scripts/guichan.lua
+++ b/scripts/guichan.lua
@@ -1261,7 +1261,7 @@ function RunSinglePlayerGameMenu()
 				end
 			end
 			GameSettings.Difficulty = difficulty:getSelected() + 1
-			GameSettings.GameType = game_type:getSelected()
+			GameSettings.GameType = game_type:getSelected() - 1
 			GameSettings.Resources = rescount:getSelected()
 			GameSettings.RevealMap = reveal_type:getSelected()
 			GameSettings.NumUnits = numunits:getSelected()


### PR DESCRIPTION
GameType must be started from -1 (for UseMapSettings), but was started from 0.

According to `settings.h`:
```
#define SettingsPresetMapDefault  -1  /// Special: Use map supplied
...
enum GameTypes {
	SettingsGameTypeMapDefault = SettingsPresetMapDefault,
	SettingsGameTypeMelee = 0,
	SettingsGameTypeFreeForAll,
	SettingsGameTypeTopVsBottom,
	SettingsGameTypeLeftVsRight,
	SettingsGameTypeManVsMachine,
	SettingsGameTypeManTeamVsMachine
```