### PR TITLE
Fix for https://github.com/Wargus/stratagus/issues/270

### DIFF
--- a/scripts/orc/anim.lua
+++ b/scripts/orc/anim.lua
@@ -418,6 +418,7 @@ DefineAnimations("animations-goblin-zeppelin", {
     "frame 0", "move 3", "wait 1", "frame 0", "move 3", "wait 1",
     "frame 0", "move 3", "wait 1", "frame 0", "move 3", "unbreakable end", "wait 1",},
   Attack = {"unbreakable begin", "frame 0", "unbreakable end", "wait 1",},
+  Death = {"unbreakable begin", "frame 0", "unbreakable end", "wait 1", },
 })
 
 

--- a/scripts/units.lua
+++ b/scripts/units.lua
@@ -80,7 +80,7 @@ function DefineUnitType(name, tbl)
       -- we just redefine always. the existing unit and animation will be
       -- overridden with the same values
       local deadVisionName = "unit-dead-vision-" .. size .. "-" .. sight
-      OldDefineAnimations("animations-dead-vision", { Still = { "wait 80", "set-var SightRange.Max = 1", "wait 80", "die" } })
+      OldDefineAnimations("animations-dead-vision", { Still = { "frame 0", "wait 80", "set-var SightRange.Max = 1", "wait 80", "die" } })
       OldDefineUnitType(deadVisionName, {
                            Name = "Reveal Death Location " .. size .. "-" .. sight,
                            TileSize = {size, size},


### PR DESCRIPTION
Let corpses always have 0 vision. Instead, generate animation step to spawn revealer when unit dies, to implement the initial unit sight range, reduction to 1, and then nothing.