### PR TITLE
Evaluation of lua-expression from in-game console.

### DIFF
--- a/scripts/cheats.lua
+++ b/scripts/cheats.lua
@@ -157,8 +157,19 @@ function HandleCheats(str)
     PlayMusic("music/I'm a Medieval Man" .. wargus.music_extension)
     AddMessage("enabled cheat")
 
+  elseif (string.find(str, ".lua")) then
+    AddMessage("Reloading " .. str)
+    Load("scripts/" .. str)
+
+  elseif (string.find(str, "eval") == 1) then
+    local code = str:gsub("^eval%s", "")
+    AddMessage("Running: " .. code)
+    local result = loadstring("return " .. code)
+    result = result()
+    AddMessage(" => " .. tostring(result))
+
   else
-	ischeater = false
+	  ischeater = false
     return false
   end
   return true

--- a/scripts/cheats.lua
+++ b/scripts/cheats.lua
@@ -186,14 +186,17 @@ function HandleCheats(str)
 
     elseif (string.find(str, ".lua")) then
       AddMessage("Reloading " .. str)
+      print("Force reloading by in-game console cmd " .. str)
       Load("scripts/" .. str)
 
     elseif (string.find(str, "eval") == 1) then
       local code = str:gsub("^eval%s", "")
       AddMessage("Running: " .. code)
+      print("Running by \'eval\' cmd: " .. code)
       local result = loadstring("return " .. code)
       result = result()
       AddMessage(" => " .. tostring(result))
+      print(" => " .. tostring(result))
     end
   else
 	  ischeater = false

--- a/scripts/cheats.lua
+++ b/scripts/cheats.lua
@@ -157,17 +157,44 @@ function HandleCheats(str)
     PlayMusic("music/I'm a Medieval Man" .. wargus.music_extension)
     AddMessage("enabled cheat")
 
-  elseif (string.find(str, ".lua")) then
-    AddMessage("Reloading " .. str)
-    Load("scripts/" .. str)
+  elseif (IsDebugEnabled) then
+    if (str == "fast debug") then
+      for i = 0,PlayerMax - 1 do
+        for j = 1,table.getn(resources) do
+        SetSpeedResourcesHarvest(i, resources[j], 1000)
+        SetSpeedResourcesReturn(i, resources[j], 1000)
+        end
+        SetSpeedBuild(i, 1000)
+        SetSpeedTrain(i, 1000)
+        SetSpeedUpgrade(i, 1000)
+        SetSpeedResearch(i, 1000)
+      end
+      AddMessage("FAST DEBUG SPEED")
 
-  elseif (string.find(str, "eval") == 1) then
-    local code = str:gsub("^eval%s", "")
-    AddMessage("Running: " .. code)
-    local result = loadstring("return " .. code)
-    result = result()
-    AddMessage(" => " .. tostring(result))
+    elseif (str == "normal debug") then
+      for i = 0,PlayerMax - 1 do
+        for j = 1,table.getn(resources) do
+        SetSpeedResourcesHarvest(i, resources[j], 100)
+        SetSpeedResourcesReturn(i, resources[j], 100)
+        end
+        SetSpeedBuild(i, 100)
+        SetSpeedTrain(i, 100)
+        SetSpeedUpgrade(i, 100)
+        SetSpeedResearch(i, 100)
+      end
+      AddMessage("NORMAL DEBUG SPEED")
 
+    elseif (string.find(str, ".lua")) then
+      AddMessage("Reloading " .. str)
+      Load("scripts/" .. str)
+
+    elseif (string.find(str, "eval") == 1) then
+      local code = str:gsub("^eval%s", "")
+      AddMessage("Running: " .. code)
+      local result = loadstring("return " .. code)
+      result = result()
+      AddMessage(" => " .. tostring(result))
+    end
   else
 	  ischeater = false
     return false


### PR DESCRIPTION
1. Added `eval` cheat which allow to execute lua expressions from in-game console.
2. Added possibility to reload whole *.lua files from `scripts` folder. You just need to enter `filename.lua` in the in-game console.
3. This features enabled only for debug version of stratagus.

NB: works only with code from this PR: https://github.com/Wargus/stratagus/pull/325