### PR TITLE
Check for argument to main to avoid segfault since ArchiveDir is set to argv[1].

### DIFF
--- a/wartool.cpp
+++ b/wartool.cpp
@@ -2667,6 +2667,11 @@ int main(int argc, char** argv)
 	char filename[8192] = {'\0'};
 	FILE* f;
 
+	if(argc == 1){
+		Usage(argv[0]);
+		return 1;
+	}
+
 	while (argc >= 2) {
 		if (!strcmp(argv[a], "-v")) {
 			video = 1;


### PR DESCRIPTION
I noticed earlier when I tried running wartool that it segfaulted if it was run with no arguments, so I added a small bit of code to print the usage information instead of continuing.  I set the exit code to be 1 in this case.  I am not sure how useful this is to you, or how you like pull requests.  