### PR TITLE
wartool: drop special handling of russian po files

### DIFF
--- a/wartool.cpp
+++ b/wartool.cpp
@@ -2527,46 +2527,6 @@ int CampaignsCreate(const char* file __attribute__((unused)), int txte, int ofs)
 	return result;
 }
 
-//----------------------------------------------------------------------------
-//  Fix SPK translation
-//----------------------------------------------------------------------------
-
-void FixTranslation(const char *translation)
-{
-	struct stat st;
-
-	if (!stat(translation, &st)) {
-		FILE *iFile = fopen(translation, "rb");
-		if (iFile == NULL) {
-			return;
-		}
-		unsigned char *buf = new unsigned char[st.st_size];
-		unsigned char *p = buf;
-		while (!feof(iFile)) {
-			*p++ = fgetc(iFile);
-		}
-		fclose(iFile);
-
-		FILE *oFile = fopen(translation, "wb");
-		if (oFile == NULL) {
-			return;
-		}
-		p = buf;
-		for (long i = 0; i < st.st_size; ++i, ++p) {
-			unsigned char c = *p;
-			if (c >= 0x80) {
-				if (c >= 0xE0 && c < 0xF0) {
-					c -= 0x30;
-				}
-				fputc(0xC2, oFile);
-				fputc(c, oFile);
-			} else {
-				fputc(c, oFile);
-			}
-		}
-	}
-}
-
 #define OUR_EXPANSION_SUBDIR "wargus.exp.data"
 
 void copyArchive(const char* partialPath) {
@@ -3454,11 +3414,6 @@ int main(int argc, char** argv)
 
 	fputs(VERSION, f);
 	fclose(f);
-
-	sprintf(buf, "%s/scripts/translate/ru_RU.po", Dir);
-	FixTranslation(buf);
-	sprintf(buf, "%s/scripts/translate/stratagus-ru.po", Dir);
-	FixTranslation(buf);
 
 	sprintf(buf, "%s/%s", Dir, REEXTRACT_MARKER_FILE);
 	f = fopen(buf, "w");


### PR DESCRIPTION
Russian po files were converted to UTF-8 in commit e7190d59 so there is no reason for special handling of strings.

Fixes: https://github.com/Wargus/wargus/issues/312#issuecomment-1312716545

There are still some letters missing because of bug (?) in stratagus font handling - I will create another PR for it.