### PR TITLE
Diplomacy Menu: Avoid removed SetDisabledColor

### DIFF
--- a/scripts/menus/diplomacy.lua
+++ b/scripts/menus/diplomacy.lua
@@ -58,9 +58,9 @@ function RunDiplomacyMenu()
 	 alliedcb:setEnabled(false)
 	 enemycb:setEnabled(false)
 	 sharedvisioncb:setEnabled(false)
-	 alliedcb:setDisabledColor(dark)
-	 enemycb:setDisabledColor(clear)
-	 sharedvisioncb:setDisabledColor(dark)
+	 alliedcb:setBaseColor(dark)
+	 enemycb:setBaseColor(clear)
+	 sharedvisioncb:setBaseColor(dark)
       end
     end
   end


### PR DESCRIPTION
Game did just exit when pressing F9.
Now that SetDisabledColor was removed from GuiChan, fall back to SetBaseColor for the disabled Checkboxes.