### PR TITLE
human mission 10: Convert attacker units with wrapped CreateUnit

### DIFF
--- a/campaigns/human/level10h_c.sms
+++ b/campaigns/human/level10h_c.sms
@@ -15,10 +15,10 @@ AddTrigger(
   function() return IfRescuedNearUnit("this", ">=", 4, "unit-attack-peasant", "unit-circle-of-power") end,
   function() return ActionVictory() end)
 
--- If we one of the attack peasants we should rescue dies, we're done
+-- If too many of the attack peasants we should rescue die, we're done.
 AddTrigger(
   function() return (GetPlayerData(4, "UnitTypesCount", "unit-attack-peasant") +
-  GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-attack-peasant")) <= 3 end,
+  GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-attack-peasant")) < 4 end,
   function() return ActionDefeat() end)
 
 AddTrigger(
@@ -166,11 +166,11 @@ DefineAi("hum-10", "*", "hum-10", AiHuman10)
 
 -- Map
 
-Load("campaigns/human/level10h.sms")
-
--- Make the player 4 units attack peasants
-for i,unit in ipairs(GetUnits(4)) do
-   if GetUnitVariable(unit, "Ident") == "unit-peasant" then
-       TransformUnit(unit, "unit-attack-peasant")
-   end
+local origCreateUnit = CreateUnit
+function CreateUnit(type, player, pos)
+  -- Make the player 4 units attack peasants
+  if player == 4 and type == "unit-peasant" then type = "unit-attack-peasant" end
+  return origCreateUnit(type, player, pos)
 end
+Load("campaigns/human/level10h.sms")
+CreateUnit = origCreateUnit


### PR DESCRIPTION
With the original TransformUnit the unit-peasant become unit-attack-peasant only in GameCycle=2.
But the Defeat-Trigger that counts them is already executed in in GameCycle=1. This trigger then counts 0 units of type 'unit-attack-peasant' and the mission is lost.

This happens since https://github.com/Wargus/stratagus/pull/626 was merged: b5e5bb0c6a18ccbf ("Merge pull request #626 from zzam/trigger-each-cycle")

Before the code was fragile but it worked due to the ordering of triggers.

Closes: https://github.com/Wargus/wargus/issues/458