### PR TITLE
correct aspect ratio of menus

### DIFF
--- a/scripts/guichan.lua
+++ b/scripts/guichan.lua
@@ -43,7 +43,7 @@ black = Color(0, 0, 0)
 
 bckground = CGraphic:New("ui/Menu_background_with_title.png")
 bckground:Load()
-bckground:Resize(Video.Width, Video.Height)
+bckground:Resize(Video.FourThreeWidth, Video.FourThreeHeight)
 backgroundWidget = ImageWidget(bckground)
 
 g_hbln = CGraphic:New("ui/human/widgets/button-large-normal.png")
@@ -783,14 +783,18 @@ function WarMenu(title, background, resize)
     bgg = CGraphic:ForceNew(background)
     bgg:Load()
     if (resize == nil or resize == true) then
-       bgg:Resize(Video.Width, Video.Height)
+       bgg:Resize(Video.FourThreeWidth, Video.FourThreeHeight)
     elseif type(resize) == "table" then
       bgg:Resize(resize[1], resize[2])
       menu:resize(resize[1], resize[2])       
     end
     bg = ImageWidget(bgg)
   end
-  menu:add(bg, 0, 0)
+  if (menu:getWidth() == Video.Width) then
+    menu:add(bg, (Video.Width - Video.FourThreeWidth) / 2, (Video.Height - Video.FourThreeHeight) / 2)
+  else
+    menu:add(bg, 0, 0)
+  end
 
   AddMenuHelpers(menu)
 

--- a/scripts/guichan.lua
+++ b/scripts/guichan.lua
@@ -790,7 +790,7 @@ function WarMenu(title, background, resize)
     end
     bg = ImageWidget(bgg)
   end
-  if (menu:getWidth() == Video.Width) then
+  if (resize == nil or resize == true) then
     menu:add(bg, (Video.Width - Video.FourThreeWidth) / 2, (Video.Height - Video.FourThreeHeight) / 2)
   else
     menu:add(bg, 0, 0)

--- a/scripts/menus/campaign.lua
+++ b/scripts/menus/campaign.lua
@@ -63,7 +63,7 @@ function Briefing(title, objs, bg, text, voices)
   l:setLineWidth(320)
   l:adjustSize()
   sw:add(l, 0, 0)
-  menu:add(sw, 70 * Video.Width / 640, 80 * Video.Height / 480)
+  menu:add(sw, Video.Width / 2 - 250 * Video.FourThreeWidth / 640, 80 * Video.Height / 480)
 
   if (objs ~= nil) then
     menu:addLabel(_("Objectives:"), 372 * Video.Width / 640, 306 * Video.Height / 480, Fonts["large"], false)

--- a/scripts/menus/options.lua
+++ b/scripts/menus/options.lua
@@ -668,7 +668,7 @@ function SetVideoSize(width, height)
    if (Video:ResizeScreen(width, height) == false) then
       return
    end
-   bckground:Resize(Video.Width, Video.Height)
+   bckground:Resize(Video.FourThreeWidth, Video.FourThreeHeight)
    backgroundWidget = ImageWidget(bckground)
    Load("scripts/ui.lua")
    wc2.preferences.VideoWidth = Video.Width
@@ -872,7 +872,7 @@ function RunOptionsSubMenu()
    menu:addFullButton(_("Preferences (~<F8~>)"), "f8", offx + 208, offy + 104 + 36*3,
      function() RunPreferencesMenu(); end)
    menu:addFullButton(_("Video (~<F9~>)"), "f9", offx + 208, offy + 104 + 36*4,
-     function() RunVideoOptionsMenu(); end)
+     function() RunVideoOptionsMenu(); menu:stop(1); RunOptionsSubMenu() end)
    menu:addFullButton(_("Language"), "f13", offx + 208, offy + 104 + 36*5,
      function() RunLanguageMenu();  end)
     


### PR DESCRIPTION
Display menu backgrounds in the original 4:3 aspect ratio, preventing the original art from being stretched.

Additionally, refresh the options menu after changing resolution so it displays correctly.

To be used in conjunction with https://github.com/Wargus/stratagus/pull/692