### PR TITLE
Remove Triggers indirection

### DIFF
--- a/campaigns/human-exp/levelx01h_c.sms
+++ b/campaigns/human-exp/levelx01h_c.sms
@@ -11,7 +11,6 @@ Briefing(
    "campaigns/human-exp/levelx01h-intro2.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return IfRescuedNearUnit("this", "==", 1, "unit-female-hero", "unit-circle-of-power") and
     IfRescuedNearUnit("this", "==", 1, "unit-arthor-literios", "unit-circle-of-power") and
@@ -29,9 +28,6 @@ AddTrigger(
  function() return GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-knight-rider") == 0 and
     GetPlayerData(0, "UnitTypesCount", "unit-knight-rider") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 

--- a/campaigns/human-exp/levelx02h_c.sms
+++ b/campaigns/human-exp/levelx02h_c.sms
@@ -11,7 +11,6 @@ Briefing(
    "campaigns/human-exp/levelx02h-intro2.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return GetNumOpponents(GetThisPlayer()) == 0 and
     GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-arthor-literios") == 1 end,
@@ -23,9 +22,6 @@ AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-arthor-literios") == 0 and
     GetPlayerData(4, "UnitTypesCount", "unit-arthor-literios") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 DefineAllowNormalHumanUnits("AAAAAAAAAAAAAAAA")

--- a/campaigns/human-exp/levelx03h_c.sms
+++ b/campaigns/human-exp/levelx03h_c.sms
@@ -11,7 +11,6 @@ Briefing(
    "campaigns/human-exp/levelx03h-intro2.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function()
     return GetPlayerData(0, "UnitTypesCount", "unit-fortress") == 0 and
@@ -30,9 +29,6 @@ AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-knight-rider") == 0 and
     GetPlayerData(6, "UnitTypesCount", "unit-knight-rider") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 DefineAllowNormalHumanUnits("AAAAAAAAAAAAAAAA")

--- a/campaigns/human-exp/levelx04h_c.sms
+++ b/campaigns/human-exp/levelx04h_c.sms
@@ -12,7 +12,6 @@ Briefing(
    "campaigns/human-exp/levelx04h-intro3.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return GetNumOpponents(GetThisPlayer()) == 0 and
     GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-castle") >= 1 end,
@@ -20,9 +19,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 local hum_exp_04a_loop_funcs = {
 	function() DebugPrint("Looping !\n") return false end,

--- a/campaigns/human-exp/levelx05h_c.sms
+++ b/campaigns/human-exp/levelx05h_c.sms
@@ -11,7 +11,6 @@ Briefing(
    "campaigns/human-exp/levelx05h-intro2.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return GetPlayerData(2, "UnitTypesCount", "unit-orc-shipyard") == 0 and
     GetPlayerData(3, "UnitTypesCount", "unit-orc-shipyard") == 0 and
@@ -22,9 +21,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 local hum_exp_05a_loop_funcs = {
 	function() DebugPrint("Looping !\n") return false end,

--- a/campaigns/human-exp/levelx06h_c.sms
+++ b/campaigns/human-exp/levelx06h_c.sms
@@ -12,7 +12,6 @@ Briefing(
    "campaigns/human-exp/levelx06h-intro3.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return 
   	GetPlayerData(5, "TotalNumUnits") == 0 and
@@ -30,9 +29,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 local hum_exp_06a_loop_funcs = {
 	function() DebugPrint("Looping !\n") return false end,

--- a/campaigns/human-exp/levelx07h_c.sms
+++ b/campaigns/human-exp/levelx07h_c.sms
@@ -12,7 +12,6 @@ Briefing(
    "campaigns/human-exp/levelx07h-intro3.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return
     GetPlayerData(2, "UnitTypesCount", "unit-fire-breeze") == 0 and
@@ -38,9 +37,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 local hum_exp_07a_loop_funcs = {
 	function() DebugPrint("Looping !\n") return false end,

--- a/campaigns/human-exp/levelx08h_c.sms
+++ b/campaigns/human-exp/levelx08h_c.sms
@@ -11,7 +11,6 @@ Briefing(
    "campaigns/human-exp/levelx08h-intro2.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return GetPlayerData(3, "TotalNumUnits") == 0 and
     GetPlayerData(6, "TotalNumUnits") == 0 and
@@ -20,9 +19,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 local hum_exp_08a_loop_funcs = {
 	function() DebugPrint("Looping !\n") return false end,

--- a/campaigns/human-exp/levelx09h_c.sms
+++ b/campaigns/human-exp/levelx09h_c.sms
@@ -11,7 +11,6 @@ Briefing(
    "campaigns/human-exp/levelx09h-intro2.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return GetPlayerData(4, "UnitTypesCount", "unit-runestone") == 0 and
     GetPlayerData(5, "UnitTypesCount", "unit-fortress") == 0 end,
@@ -19,9 +18,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 local hum_exp_09a_loop_funcs = {
 	function() DebugPrint("Looping !\n") return false end,

--- a/campaigns/human-exp/levelx10h_c.sms
+++ b/campaigns/human-exp/levelx10h_c.sms
@@ -12,7 +12,6 @@ Briefing(
    "campaigns/human-exp/levelx10h-intro3.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return GetPlayerData(2, "TotalNumUnits") == 0 and
     GetPlayerData(3, "TotalNumUnits") == 0 and
@@ -41,9 +40,6 @@ AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-knight-rider") == 0 and
     GetPlayerData(0, "UnitTypesCount", "unit-knight-rider") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 local hum_exp_10a_loop_funcs = {
 	function() DebugPrint("Looping !\n") return false end,

--- a/campaigns/human-exp/levelx11h_c.sms
+++ b/campaigns/human-exp/levelx11h_c.sms
@@ -11,7 +11,6 @@ Briefing(
    "campaigns/human-exp/levelx11h-intro2.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return GetPlayerData(2, "TotalNumUnits") == 0 and
     GetPlayerData(3, "TotalNumUnits") == 0 end,
@@ -31,9 +30,6 @@ AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-knight-rider") == 0 and
     GetPlayerData(0, "UnitTypesCount", "unit-knight-rider") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 local hum_exp_11a_loop_funcs = {
 	function() DebugPrint("Looping !\n") return false end,

--- a/campaigns/human-exp/levelx12h_c.sms
+++ b/campaigns/human-exp/levelx12h_c.sms
@@ -11,7 +11,6 @@ Briefing(
    "campaigns/human-exp/levelx12h-intro2.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return GetPlayerData(15, "UnitTypesCount", "unit-dark-portal") == 0 end,
   function() return ActionVictory() end)
@@ -22,9 +21,6 @@ AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-white-mage") == 0 and
     GetPlayerData(4, "UnitTypesCount", "unit-white-mage") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 local hum_exp_12a_loop_funcs = {
 	function() DebugPrint("Looping !\n") return false end,

--- a/campaigns/human/level01h_c.sms
+++ b/campaigns/human/level01h_c.sms
@@ -11,7 +11,6 @@ Briefing(
    "campaigns/human/level01h-intro2.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-farm") >= 4 and
 		GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-human-barracks") >= 1 end,
@@ -19,9 +18,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 local allowedHumanUnits = {"unit-farm",

--- a/campaigns/human/level02h_c.sms
+++ b/campaigns/human/level02h_c.sms
@@ -11,7 +11,6 @@ Briefing(
    "campaigns/human/level02h-intro2.wav"}
 )
 
-Triggers = [[
 local cycle2Win = 120
 AddTrigger(
   function()
@@ -34,9 +33,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 local allowedHumanUnits = {"unit-farm",

--- a/campaigns/human/level03h_c.sms
+++ b/campaigns/human/level03h_c.sms
@@ -11,7 +11,6 @@ Briefing(
    "campaigns/human/level03h-intro2.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-human-shipyard") >= 1 and
     GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-human-oil-platform") >= 4 end,
@@ -19,9 +18,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 local allowedHumanUnits = {"unit-farm",

--- a/campaigns/human/level04h_c.sms
+++ b/campaigns/human/level04h_c.sms
@@ -11,16 +11,12 @@ Briefing(
    "campaigns/human/level04h-intro2.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return GetNumOpponents(GetThisPlayer()) == 0 end,
   function() return ActionVictory() end)
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 local allowedHumanUnits = {"unit-farm",

--- a/campaigns/human/level05h_c.sms
+++ b/campaigns/human/level05h_c.sms
@@ -11,16 +11,12 @@ Briefing(
    "campaigns/human/level05h-intro2.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return GetNumOpponents(GetThisPlayer()) == 0 end,
   function() return ActionVictory() end)
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 local allowedHumanUnits = {"unit-farm",

--- a/campaigns/human/level06h_c.sms
+++ b/campaigns/human/level06h_c.sms
@@ -10,16 +10,12 @@ Briefing(
   {"campaigns/human/level06h-intro1.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return GetNumOpponents(GetThisPlayer()) == 0 end,
   function() return ActionVictory() end)
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 local allowedHumanUnits = {"unit-farm",

--- a/campaigns/human/level07h_c.sms
+++ b/campaigns/human/level07h_c.sms
@@ -11,16 +11,12 @@ Briefing(
    "campaigns/human/level07h-intro2.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return GetPlayerData(2, "UnitTypesCount", "unit-orc-refinery") == 0 end,
   function() return ActionVictory() end)
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 local allowedHumanUnits = {"unit-farm",

--- a/campaigns/human/level08h_c.sms
+++ b/campaigns/human/level08h_c.sms
@@ -11,7 +11,6 @@ Briefing(
    "campaigns/human/level08h-intro2.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return true end,
   function() SetDiplomacy(4, "enemy", 2)
@@ -29,9 +28,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 local allowedHumanUnits = {"unit-farm",

--- a/campaigns/human/level09h_c.sms
+++ b/campaigns/human/level09h_c.sms
@@ -10,7 +10,6 @@ Briefing(
   {"campaigns/human/level09h-intro1.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return IfNearUnit("this", "==", 1, "unit-man-of-light", "unit-circle-of-power") end,
   function() return ActionVictory() end)
@@ -22,9 +21,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 local allowedOrcUnits = {"unit-pig-farm",

--- a/campaigns/human/level10h_c.sms
+++ b/campaigns/human/level10h_c.sms
@@ -10,7 +10,6 @@ Briefing(
   {"campaigns/human/level10h-intro1.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return IfRescuedNearUnit("this", ">=", 4, "unit-attack-peasant", "unit-circle-of-power") end,
   function() return ActionVictory() end)
@@ -24,9 +23,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 local allowedHumanUnits = {"unit-farm",

--- a/campaigns/human/level11h_c.sms
+++ b/campaigns/human/level11h_c.sms
@@ -11,7 +11,6 @@ Briefing(
    "campaigns/human/level11h-intro2.wav"}
 )
 
-Triggers = [[
 -- FIXME: Check if units are freed.
 
 AddTrigger(
@@ -22,9 +21,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 local allowedHumanUnits = {"unit-farm",

--- a/campaigns/human/level12h_c.sms
+++ b/campaigns/human/level12h_c.sms
@@ -10,7 +10,6 @@ Briefing(
   {"campaigns/human/level12h-intro1.wav"}
 )
 
-Triggers = [[
 -- FIXME: Check if units are destroyed.
 
 AddTrigger(
@@ -25,9 +24,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 local allowedHumanUnits = {"unit-farm",

--- a/campaigns/human/level13h_c.sms
+++ b/campaigns/human/level13h_c.sms
@@ -11,7 +11,6 @@ Briefing(
    "campaigns/human/level13h-intro2.wav"}
 )
 
-Triggers = [[
 -- FIXME: Check if units are destroyed.
 
 AddTrigger(
@@ -21,9 +20,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 local allowedHumanUnits = {"unit-farm",

--- a/campaigns/human/level14h_c.sms
+++ b/campaigns/human/level14h_c.sms
@@ -10,7 +10,6 @@ Briefing(
   {"campaigns/human/level14h-intro1.wav"}
 )
 
-Triggers = [[
 -- FIXME: Check if units are destroyed.
 
 AddTrigger(
@@ -20,9 +19,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 local allowedHumanUnits = {"unit-farm",

--- a/campaigns/orc-exp/levelx01o_c.sms
+++ b/campaigns/orc-exp/levelx01o_c.sms
@@ -12,7 +12,6 @@ Briefing(
    "campaigns/orc-exp/levelx01o-intro3.wav"}
 )
 
-Triggers = [[
 -- FIXME: Check if units are destroyed.
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-beast-cry") == 1 and
@@ -28,9 +27,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 DefineAllowNormalHumanUnits("AAAAAAAAAAAAAAAA")

--- a/campaigns/orc-exp/levelx02o_c.sms
+++ b/campaigns/orc-exp/levelx02o_c.sms
@@ -11,7 +11,6 @@ Briefing(
    "campaigns/orc-exp/levelx02o-intro2.wav"}
 )
 
-Triggers = [[
 -- FIXME: Check if units are destroyed.
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-quick-blade") == 1 and
@@ -32,9 +31,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 DefineAllowNormalHumanUnits("AAAAAAAAAAAAAAAA")

--- a/campaigns/orc-exp/levelx03o_c.sms
+++ b/campaigns/orc-exp/levelx03o_c.sms
@@ -11,7 +11,6 @@ Briefing(
    "campaigns/orc-exp/levelx03o-intro2.wav"}
 )
 
-Triggers = [[
 -- FIXME: Check if units are destroyed.
 AddTrigger(
   function() return GetNumOpponents(GetThisPlayer()) == 0 end,
@@ -20,9 +19,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 DefineAllowNormalHumanUnits("AAAAAAAAAAAAAAAA")

--- a/campaigns/orc-exp/levelx04o_c.sms
+++ b/campaigns/orc-exp/levelx04o_c.sms
@@ -11,7 +11,6 @@ Briefing(
    "campaigns/orc-exp/levelx04o-intro2.wav"}
 )
 
-Triggers = [[
 -- FIXME: Check if units are destroyed.
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-evil-knight") == 1 and
@@ -26,9 +25,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 DefineAllowNormalHumanUnits("AAAAAAAAAAAAAAAA")

--- a/campaigns/orc-exp/levelx05o_c.sms
+++ b/campaigns/orc-exp/levelx05o_c.sms
@@ -11,7 +11,6 @@ Briefing(
    "campaigns/orc-exp/levelx05o-intro2.wav"}
 )
 
-Triggers = [[
 -- FIXME: Check if units are destroyed.
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-dragon-roost") == 1 end,
@@ -20,9 +19,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 DefineAllowNormalHumanUnits("AAAAAAAAAAAAAAAA")

--- a/campaigns/orc-exp/levelx06o_c.sms
+++ b/campaigns/orc-exp/levelx06o_c.sms
@@ -11,7 +11,6 @@ Briefing(
    "campaigns/orc-exp/levelx06o-intro2.wav"}
 )
 
-Triggers = [[
 -- FIXME: Check if units are destroyed.
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-evil-knight") == 1 and
@@ -26,9 +25,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 DefineAllowNormalHumanUnits("AAAAAAAAAAAAAAAA")

--- a/campaigns/orc-exp/levelx07o_c.sms
+++ b/campaigns/orc-exp/levelx07o_c.sms
@@ -12,7 +12,6 @@ Briefing(
    "campaigns/orc-exp/levelx07o-intro3.wav"}
 )
 
-Triggers = [[
 -- FIXME: Check if units are destroyed.
 AddTrigger(
 
@@ -28,9 +27,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 DefineAllowNormalHumanUnits("AAAAAAAAAAAAAAAA")

--- a/campaigns/orc-exp/levelx08o_c.sms
+++ b/campaigns/orc-exp/levelx08o_c.sms
@@ -10,7 +10,6 @@ Briefing(
   {"campaigns/orc-exp/levelx08o-intro1.wav"}
 )
 
-Triggers = [[
 -- FIXME: Check if units are destroyed.
 AddTrigger(
   function() return GetNumOpponents(GetThisPlayer()) == 0 end,
@@ -19,9 +18,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 DefineAllowNormalHumanUnits("AAAAAAAAAAAAAAAA")

--- a/campaigns/orc-exp/levelx09o_c.sms
+++ b/campaigns/orc-exp/levelx09o_c.sms
@@ -11,7 +11,6 @@ Briefing(
    "campaigns/orc-exp/levelx09o-intro2.wav"}
 )
 
-Triggers = [[
 -- FIXME: Check if units are destroyed.
 AddTrigger(
   function() return GetPlayerData(1, "UnitTypesCount", "unit-daemon") == 0 end,
@@ -20,9 +19,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 DefineAllowNormalHumanUnits("AAAAAAAAAAAAAAAA")

--- a/campaigns/orc-exp/levelx10o_c.sms
+++ b/campaigns/orc-exp/levelx10o_c.sms
@@ -12,7 +12,6 @@ Briefing(
    "campaigns/orc-exp/levelx10o-intro3.wav"}
 )
 
-Triggers = [[
 -- FIXME: Check if units are destroyed.
 AddTrigger(
   function() return IfRescuedNearUnit("this", "==", 1, "unit-mage", "unit-circle-of-power") and
@@ -22,9 +21,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 DefineAllowNormalHumanUnits("AAAAAAAAAAAAAAAA")

--- a/campaigns/orc-exp/levelx11o_c.sms
+++ b/campaigns/orc-exp/levelx11o_c.sms
@@ -11,7 +11,6 @@ Briefing(
    "campaigns/orc-exp/levelx11o-intro2.wav"}
 )
 
-Triggers = [[
 -- FIXME: Check if units are destroyed.
 AddTrigger(
   function() return GetPlayerData(3, "TotalNumUnits") == 0 and
@@ -21,9 +20,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 DefineAllowNormalHumanUnits("AAAAAAAAAAAAAAAA")

--- a/campaigns/orc-exp/levelx12o_c.sms
+++ b/campaigns/orc-exp/levelx12o_c.sms
@@ -12,7 +12,6 @@ Briefing(
    "campaigns/orc-exp/levelx12o-intro3.wav"}
 )
 
-Triggers = [[
 -- FIXME: Check if units are destroyed.
 AddTrigger(
   function() return GetNumOpponents(GetThisPlayer()) == 0 end,
@@ -21,9 +20,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 DefineAllowNormalHumanUnits("AAAAAAAAAAAAAAAA")

--- a/campaigns/orc/level01o_c.sms
+++ b/campaigns/orc/level01o_c.sms
@@ -10,7 +10,6 @@ Briefing(
   {"campaigns/orc/level01o-intro1.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-pig-farm") >= 4 and
     GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-orc-barracks") >= 1 end,
@@ -18,9 +17,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 -- Units
 

--- a/campaigns/orc/level02o_c.sms
+++ b/campaigns/orc/level02o_c.sms
@@ -10,7 +10,6 @@ Briefing(
   {"campaigns/orc/level02o-intro1.wav"}
 )
 
-Triggers = [[
 HaveUnitSharpAxe = nil
 
 AddTrigger(
@@ -30,9 +29,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 -- Units
 

--- a/campaigns/orc/level03o_c.sms
+++ b/campaigns/orc/level03o_c.sms
@@ -11,7 +11,6 @@ Briefing(
    "campaigns/orc/level03o-intro2.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-orc-shipyard") >= 1 and
     GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-orc-oil-platform") >= 4 end,
@@ -19,9 +18,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 

--- a/campaigns/orc/level04o_c.sms
+++ b/campaigns/orc/level04o_c.sms
@@ -11,16 +11,12 @@ Briefing(
 )
 
 
-Triggers = [[
 AddTrigger(
 	function() return GetNumOpponents(GetThisPlayer()) == 0 end,
 	function() return ActionVictory() end)
 AddTrigger(
 	function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
 	function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 local allowedHumanUnits = {"unit-farm",
 	"unit-town-hall", "unit-peasant",

--- a/campaigns/orc/level05o_c.sms
+++ b/campaigns/orc/level05o_c.sms
@@ -10,16 +10,12 @@ Briefing(
   {"campaigns/orc/level05o-intro1.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return GetNumOpponents(GetThisPlayer()) == 0 end,
   function() return ActionVictory() end)
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 local allowedHumanUnits = {"unit-farm",

--- a/campaigns/orc/level06o_c.sms
+++ b/campaigns/orc/level06o_c.sms
@@ -10,7 +10,6 @@ Briefing(
   {"campaigns/orc/level06o-intro1.wav"}
 )
 
-Triggers = [[
 AddTrigger(
    function() return IfNearUnit("this", "==", 1, "unit-double-head", "unit-circle-of-power") end,
    function() return ActionVictory() end)
@@ -21,9 +20,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
    function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 

--- a/campaigns/orc/level07o_c.sms
+++ b/campaigns/orc/level07o_c.sms
@@ -11,16 +11,12 @@ Briefing(
    "campaigns/orc/level07o-intro2.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return GetNumOpponents(GetThisPlayer()) == 0 end,
   function() return ActionVictory() end)
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 

--- a/campaigns/orc/level08o_c.sms
+++ b/campaigns/orc/level08o_c.sms
@@ -12,7 +12,6 @@ Briefing(
   {"campaigns/orc/level08o-intro1.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return GetPlayerData(7, "UnitTypesCount", "unit-runestone") == 0 and
     GetPlayerData(1, "UnitTypesCount", "unit-castle") == 0 end,
@@ -20,9 +19,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 local allowedHumanUnits = {"unit-farm",

--- a/campaigns/orc/level09o_c.sms
+++ b/campaigns/orc/level09o_c.sms
@@ -10,7 +10,6 @@ Briefing(
   {"campaigns/orc/level09o-intro1.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return GetNumUnitsAt(GetThisPlayer(), "unit-fortress", {52, 15}, {72, 40}) >0 and
     GetNumUnitsAt(GetThisPlayer(), "unit-orc-shipyard", {48, 20}, {69, 42}) >0 end,
@@ -34,9 +33,6 @@ AddTrigger(
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 local allowedHumanUnits = {"unit-farm",

--- a/campaigns/orc/level10o_c.sms
+++ b/campaigns/orc/level10o_c.sms
@@ -10,16 +10,12 @@ Briefing(
   {"campaigns/orc/level10o-intro1.wav"}
 )
 
-Triggers = [[
 AddTrigger(
   function() return GetNumOpponents(GetThisPlayer()) == 0 end,
   function() return ActionVictory() end)
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 local allowedHumanUnits = {"unit-farm",

--- a/campaigns/orc/level11o_c.sms
+++ b/campaigns/orc/level11o_c.sms
@@ -13,16 +13,12 @@ Briefing(
 
 -- FIXME: Check if units are freed.
 
-Triggers = [[
 AddTrigger(
   function() return GetNumOpponents(GetThisPlayer()) == 0 end,
   function() return ActionVictory() end)
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 local allowedHumanUnits = {"unit-farm",

--- a/campaigns/orc/level12o_c.sms
+++ b/campaigns/orc/level12o_c.sms
@@ -12,16 +12,12 @@ Briefing(
 )
 -- FIXME: Check if units are destroyed.
 
-Triggers = [[
 AddTrigger(
   function() return GetNumOpponents(GetThisPlayer()) == 0 end,
   function() return ActionVictory() end)
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 local allowedHumanUnits = {"unit-farm",

--- a/campaigns/orc/level13o_c.sms
+++ b/campaigns/orc/level13o_c.sms
@@ -13,16 +13,12 @@ Briefing(
 
 -- FIXME: Check if units are destroyed.
 
-Triggers = [[
 AddTrigger(
   function() return GetNumOpponents(GetThisPlayer()) == 0 end,
   function() return ActionVictory() end)
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 local allowedHumanUnits = {"unit-farm",

--- a/campaigns/orc/level14o_c.sms
+++ b/campaigns/orc/level14o_c.sms
@@ -12,16 +12,12 @@ Briefing(
 
 -- FIXME: Check if units are destroyed.
 
-Triggers = [[
 AddTrigger(
   function() return GetNumOpponents(GetThisPlayer()) == 0 end,
   function() return ActionVictory() end)
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
-]]
-
-assert(loadstring(Triggers))()
 
 --Units
 local allowedHumanUnits = {"unit-farm",

--- a/maps/fl/(6)canyon-way.sms
+++ b/maps/fl/(6)canyon-way.sms
@@ -16492,7 +16492,6 @@ if (not IsNetworkGame()) then
 	end
 end
 
-Triggers = [[
 AddTrigger(
 	function() return (IsNetworkGame()) end, 
 	function()	if (GameCycle == 5) then
@@ -16516,5 +16515,3 @@ AddTrigger(
 					ActionVictory() 
 				end
 return true end)
-]]
-assert(loadstring(Triggers))()

--- a/maps/fl/(8)rockfort-arena.sms
+++ b/maps/fl/(8)rockfort-arena.sms
@@ -12754,7 +12754,6 @@ if (not IsNetworkGame()) then
 	AiRedRibbon_Diplomacy_Neutral_2014(0,9,13,"enemy")
 end
 
-Triggers = [[
 AddTrigger(
 	function() return (IsNetworkGame()) end, 
 	function()	if (GameCycle == 5) then
@@ -12771,5 +12770,3 @@ AddTrigger(
 					ActionVictory() 
 				end
 return true end)
-]]
-assert(loadstring(Triggers))()

--- a/maps/ftm/(2)forgotten-forest.sms
+++ b/maps/ftm/(2)forgotten-forest.sms
@@ -16693,7 +16693,6 @@ BlueFlyerBuilding_y = 250
 BlueTownHall_x = 30
 BlueTownHall_y = 230
 
-Triggers = [[
 AddTrigger(
 	function() return ((GameCycle > 300) and (GameCycle < 310)) end,
 	function()	AddMessage("In the red corner we have Wise Skeleton!")
@@ -16822,8 +16821,6 @@ AddTrigger(
 					ActionVictory() 
 				end
 return true end)
-]]
-assert(loadstring(Triggers))()
 
 BlueTeam1_Order = "Bottom-Right"
 RedTeam1_Order = "Top-Left"

--- a/maps/ftm/(2)less-than-three.sms
+++ b/maps/ftm/(2)less-than-three.sms
@@ -16548,7 +16548,6 @@ BlueFlyerBuilding_y = 126
 BlueTownHall_x = 117
 BlueTownHall_y = 96
 
-Triggers = [[
 
 AddTrigger(
 	function() return ((GameCycle > 300) and (GameCycle < 310)) end,
@@ -16669,5 +16668,3 @@ AddTrigger(
 					ActionVictory() 
 				end
 return true end)
-]]
-assert(loadstring(Triggers))()

--- a/maps/ftm/(2)mushroom-panic.sms
+++ b/maps/ftm/(2)mushroom-panic.sms
@@ -16696,7 +16696,6 @@ if (not IsNetworkGame()) then
 	AiRedRibbon_Pickers_Add_2014(2, 3)
 end
 
-Triggers = [[
 AddTrigger(
 	function() return (IsNetworkGame()) end, 
 	function()	if (GameCycle == 5) then
@@ -16714,5 +16713,3 @@ AddTrigger(
 					ActionVictory() 
 				end
 return true end)
-]]
-assert(loadstring(Triggers))()

--- a/maps/ftm/(2)nicks-duel.sms
+++ b/maps/ftm/(2)nicks-duel.sms
@@ -1097,7 +1097,6 @@ if (not IsNetworkGame()) then
 	AiRedRibbon_Pickers_Add_2014(10, 11)
 end
 
-Triggers = [[
 AddTrigger(
 	function() return (IsNetworkGame()) end, 
 	function()	if (GameCycle == 5) then
@@ -1115,5 +1114,3 @@ AddTrigger(
 					ActionVictory() 
 				end
 return true end)
-]]
-assert(loadstring(Triggers))()

--- a/maps/ftm/(2)one-way-through.sms
+++ b/maps/ftm/(2)one-way-through.sms
@@ -4320,7 +4320,6 @@ if (not IsNetworkGame()) then
 	AiRedRibbon_Pickers_Add_2014(13, 14)
 end
 
-Triggers = [[
 AddTrigger(
 	function() return (IsNetworkGame()) end, 
 	function()	if (GameCycle == 5) then
@@ -4338,5 +4337,3 @@ AddTrigger(
 					ActionVictory() 
 				end
 return true end)
-]]
-assert(loadstring(Triggers))()

--- a/maps/ftm/(4)beethoven-day.sms
+++ b/maps/ftm/(4)beethoven-day.sms
@@ -16649,7 +16649,6 @@ BlueFlyerBuilding_x = 17
 BlueFlyerBuilding_y = 125
 BlueTownHall_x = 18
 BlueTownHall_y = 116
-Triggers = [[
 AddTrigger(
 	function() return ((GameCycle > 300) and (GameCycle < 310)) end,
 	function()	if ((GetPlayerData(4, "Name") == "Neutral") and (GetPlayerData(7, "Name") == "Neutral")) then 
@@ -16917,6 +16916,3 @@ AddTrigger(
 	RedTemp_x2 = RedTeam2_x2
 	RedTemp_y2 = RedTeam2_y2
 return false end)
-]]
-
-assert(loadstring(Triggers))()

--- a/maps/ftm/(4)coastal-crusade.sms
+++ b/maps/ftm/(4)coastal-crusade.sms
@@ -9384,7 +9384,6 @@ if (not IsNetworkGame()) then
 	AiRedRibbon_Pickers_Add_2014(8, 14)
 end
 
-Triggers = [[
 AddTrigger(
 	function() return (IsNetworkGame()) end, 
 	function()	if (GameCycle == 5) then
@@ -9402,5 +9401,3 @@ AddTrigger(
 					ActionVictory() 
 				end
 return true end)
-]]
-assert(loadstring(Triggers))()

--- a/maps/ftm/(4)river-crossing.sms
+++ b/maps/ftm/(4)river-crossing.sms
@@ -24925,7 +24925,6 @@ BlueFlyerBuilding_y = 16
 BlueTownHall_x = 14
 BlueTownHall_y = 14
 
-Triggers = [[
 AddTrigger(
 	function() return ((GameCycle > 300) and (GameCycle < 310)) end,
 	function()	if ((GetPlayerData(RedTeam1, "Name") == "Neutral") and (GetPlayerData(RedTeam2, "Name") == "Neutral")) then 
@@ -25185,6 +25184,3 @@ AddTrigger(
 	RedTemp_x2 = RedTeam2_x2
 	RedTemp_y2 = RedTeam2_y2
 return false end)
-]]
-
-assert(loadstring(Triggers))()

--- a/maps/ftm/(4)rockfort-arena.sms
+++ b/maps/ftm/(4)rockfort-arena.sms
@@ -9449,7 +9449,6 @@ if (not IsNetworkGame()) then
 	AiRedRibbon_Pickers_Add_2014(8, 14)
 end
 
-Triggers = [[
 AddTrigger(
 	function() return (IsNetworkGame()) end, 
 	function()	if (GameCycle == 5) then
@@ -9467,5 +9466,3 @@ AddTrigger(
 					ActionVictory() 
 				end
 return true end)
-]]
-assert(loadstring(Triggers))()

--- a/maps/ftm/(4)winter-bloodbath.sms
+++ b/maps/ftm/(4)winter-bloodbath.sms
@@ -24822,7 +24822,6 @@ BlueFlyerBuilding_y = 16
 BlueTownHall_x = 45
 BlueTownHall_y = 45
 
-Triggers = [[
 AddTrigger(
 	function() return ((GameCycle > 300) and (GameCycle < 310)) end,
 	function()	if ((GetPlayerData(RedTeam1, "Name") == "Neutral") and (GetPlayerData(RedTeam2, "Name") == "Neutral")) then 
@@ -25082,6 +25081,3 @@ AddTrigger(
 	RedTemp_x2 = RedTeam2_x2
 	RedTemp_y2 = RedTeam2_y2
 return false end)
-]]
-
-assert(loadstring(Triggers))()

--- a/maps/ftm/(5)black-flood.sms
+++ b/maps/ftm/(5)black-flood.sms
@@ -9459,7 +9459,6 @@ if (not IsNetworkGame()) then
 	AiRedRibbon_Pickers_Add_2014(8, 14)
 end
 
-Triggers = [[
 AddTrigger(
 	function() return (IsNetworkGame()) end, 
 	function()	if (GameCycle == 5) then
@@ -9477,6 +9476,4 @@ AddTrigger(
 					ActionVictory() 
 				end
 return true end)
-]]
-assert(loadstring(Triggers))()
 

--- a/maps/ftm/(8)darius.sms
+++ b/maps/ftm/(8)darius.sms
@@ -8652,7 +8652,6 @@ if (not IsNetworkGame()) then
 	AiRedRibbon_Pickers_Add_2014(8, 15)
 end
 
-Triggers = [[
 AddTrigger(
 	function() return (IsNetworkGame()) end, 
 	function()	if (GameCycle == 5) then
@@ -8669,5 +8668,3 @@ AddTrigger(
 					ActionVictory() 
 				end
 return true end)
-]]
-assert(loadstring(Triggers))()


### PR DESCRIPTION
The variable Triggers was initially needed for game save/load. Since the original map file is loaded also, it is no longer needed. Simplify by removing the indirection.
