### PR TITLE
CI: Use actions/checkout to clone stratagus

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -42,7 +42,7 @@ jobs:
         path: stratagus
 
     - name: Install dependencies
-      run: brew install dylibbundler sdl2 sdl2_mixer sdl2_image lua ffmpeg meson
+      run: brew install dylibbundler sdl2 sdl2_mixer sdl2_image lua ffmpeg
 
     - name: cmake --version
       run: cmake --version

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,20 +27,28 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - name: Checkout
+    - name: Checkout Wargus
       uses: actions/checkout@v4
       with:
+        repository: Wargus/wargus
         submodules: recursive
+        path: wargus
+        
+    - name: Checkout Stratagus
+      uses: actions/checkout@v4
+      with: 
+        repository: Wargus/stratagus
+        submodules: recursive
+        path: stratagus
 
     - name: Install dependencies
-      run: brew install dylibbundler sdl2 sdl2_mixer sdl2_image lua libpng ffmpeg meson
+      run: brew install dylibbundler sdl2 sdl2_mixer sdl2_image lua ffmpeg meson
 
     - name: cmake --version
       run: cmake --version
 
     - name: Build Stratagus
       run: |
-        git clone --recursive https://github.com/Wargus/stratagus
         cmake stratagus -B stratagus/build \ -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_VENDORED_LUA=ON \
         -DBUILD_VENDORED_SDL=OFF \
@@ -50,10 +58,10 @@ jobs:
     
     - name: Build Wargus
       run: |
-        cmake . -B build \
-        -DSTRATAGUS_INCLUDE_DIR=stratagus/gameheaders \
-        -DSTRATAGUS=stratagus/build/stratagus 
-        cmake --build build --config Release
+        cmake wargus -B wargus/build \
+        -DSTRATAGUS_INCLUDE_DIR=../stratagus/gameheaders \
+        -DSTRATAGUS=../stratagus/build/stratagus 
+        cmake --build wargus/build --config Release
 
     - name: Create Wargus app bundle
       run: |
@@ -61,27 +69,27 @@ jobs:
         mkdir -p Wargus.app/Contents/Resources
         mkdir -p Wargus.app/Contents/MacOS
         
-        cp mac/Info.plist Wargus.app/Contents/
+        cp wargus/mac/Info.plist Wargus.app/Contents/
         
         mkdir wargus.iconset
-        sips -z 16 16     wargus.png --out wargus.iconset/icon_16x16.png
-        sips -z 32 32     wargus.png --out wargus.iconset/icon_16x16@2x.png
-        sips -z 32 32     wargus.png --out wargus.iconset/icon_32x32.png
-        sips -z 64 64     wargus.png --out wargus.iconset/icon_32x32@2x.png
-        sips -z 128 128   wargus.png --out wargus.iconset/icon_128x128.png
-        sips -z 256 256   wargus.png --out wargus.iconset/icon_128x128@2x.png
-        sips -z 256 256   wargus.png --out wargus.iconset/icon_256x256.png
-        sips -z 512 512   wargus.png --out wargus.iconset/icon_256x256@2x.png
-        sips -z 512 512   wargus.png --out wargus.iconset/icon_512x512.png
-        sips -z 1024 1024   wargus.png --out wargus.iconset/icon_512x512@2x.png
+        sips -z 16 16     wargus/wargus.png --out wargus.iconset/icon_16x16.png
+        sips -z 32 32     wargus/wargus.png --out wargus.iconset/icon_16x16@2x.png
+        sips -z 32 32     wargus/wargus.png --out wargus.iconset/icon_32x32.png
+        sips -z 64 64     wargus/wargus.png --out wargus.iconset/icon_32x32@2x.png
+        sips -z 128 128   wargus/wargus.png --out wargus.iconset/icon_128x128.png
+        sips -z 256 256   wargus/wargus.png --out wargus.iconset/icon_128x128@2x.png
+        sips -z 256 256   wargus/wargus.png --out wargus.iconset/icon_256x256.png
+        sips -z 512 512   wargus/wargus.png --out wargus.iconset/icon_256x256@2x.png
+        sips -z 512 512   wargus/wargus.png --out wargus.iconset/icon_512x512.png
+        sips -z 1024 1024   wargus/wargus.png --out wargus.iconset/icon_512x512@2x.png
         iconutil -c icns wargus.iconset
         rm -R wargus.iconset
         mv wargus.icns Wargus.app/Contents/Resources/
         
-        cp -R shaders campaigns contrib maps scripts Wargus.app/Contents/MacOS/
+        cp -R wargus/shaders wargus/campaigns wargus/contrib wargus/maps wargus/scripts Wargus.app/Contents/MacOS/
         
-        cp build/wartool Wargus.app/Contents/MacOS/
-        cp build/wargus Wargus.app/Contents/MacOS/
+        cp wargus/build/wartool Wargus.app/Contents/MacOS/
+        cp wargus/build/wargus Wargus.app/Contents/MacOS/
         cp stratagus/build/stratagus Wargus.app/Contents/MacOS/stratagus
         
         dylibbundler -of -cd -b -x Wargus.app/Contents/MacOS/stratagus -d Wargus.app/Contents/libs/


### PR DESCRIPTION
This uses actions/checkout instead of cloning stratagus. 

Also silences a warning about `libpng` already being installed.

Edit: Also remove Mesen, as it's used for compiling Stargus. It's not used for Wargus. 