### PR TITLE
Cleanup macOS CI by using the bundle script

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,4 @@
-name: macos-arm64
+name: macOS-arm64
 
 on:
   workflow_dispatch:
@@ -49,7 +49,8 @@ jobs:
 
     - name: Build Stratagus
       run: |
-        cmake stratagus -B stratagus/build \ -DCMAKE_BUILD_TYPE=Release \
+        cmake stratagus -B stratagus/build \
+        -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_VENDORED_LUA=ON \
         -DBUILD_VENDORED_SDL=OFF \
         -DBUILD_VENDORED_MEDIA_LIBS=OFF \
@@ -65,40 +66,17 @@ jobs:
 
     - name: Create Wargus app bundle
       run: |
-        rm -rf Wargus.app
-        mkdir -p Wargus.app/Contents/Resources
-        mkdir -p Wargus.app/Contents/MacOS
+        export STRATAGUS_INCLUDE_DIR=stratagus/gameheaders
+        export STRATAGUS=stratagus/build/stratagus
+        wargus/mac/bundle.sh
         
-        cp wargus/mac/Info.plist Wargus.app/Contents/
+        dylibbundler -of -cd -b -x wargus/mac/Wargus.app/Contents/MacOS/stratagus -d wargus/mac/Wargus.app/Contents/libs/
+        dylibbundler -of -cd -b -x wargus/mac/Wargus.app/Contents/MacOS/wartool -d wargus/mac/Wargus.app/Contents/libs/
         
-        mkdir wargus.iconset
-        sips -z 16 16     wargus/wargus.png --out wargus.iconset/icon_16x16.png
-        sips -z 32 32     wargus/wargus.png --out wargus.iconset/icon_16x16@2x.png
-        sips -z 32 32     wargus/wargus.png --out wargus.iconset/icon_32x32.png
-        sips -z 64 64     wargus/wargus.png --out wargus.iconset/icon_32x32@2x.png
-        sips -z 128 128   wargus/wargus.png --out wargus.iconset/icon_128x128.png
-        sips -z 256 256   wargus/wargus.png --out wargus.iconset/icon_128x128@2x.png
-        sips -z 256 256   wargus/wargus.png --out wargus.iconset/icon_256x256.png
-        sips -z 512 512   wargus/wargus.png --out wargus.iconset/icon_256x256@2x.png
-        sips -z 512 512   wargus/wargus.png --out wargus.iconset/icon_512x512.png
-        sips -z 1024 1024   wargus/wargus.png --out wargus.iconset/icon_512x512@2x.png
-        iconutil -c icns wargus.iconset
-        rm -R wargus.iconset
-        mv wargus.icns Wargus.app/Contents/Resources/
-        
-        cp -R wargus/shaders wargus/campaigns wargus/contrib wargus/maps wargus/scripts Wargus.app/Contents/MacOS/
-        
-        cp wargus/build/wartool Wargus.app/Contents/MacOS/
-        cp wargus/build/wargus Wargus.app/Contents/MacOS/
-        cp stratagus/build/stratagus Wargus.app/Contents/MacOS/stratagus
-        
-        dylibbundler -of -cd -b -x Wargus.app/Contents/MacOS/stratagus -d Wargus.app/Contents/libs/
-        dylibbundler -of -cd -b -x Wargus.app/Contents/MacOS/wartool -d Wargus.app/Contents/libs/
-        
-        codesign --force --deep --sign - Wargus.app
+        codesign --force --deep --sign - wargus/mac/Wargus.app
         
     - name: Create dmg
-      run: hdiutil create -volname "Wargus" -srcfolder "Wargus.app" "Wargus-arm64"
+      run: hdiutil create -volname "Wargus" -srcfolder "wargus/mac/Wargus.app" "Wargus-arm64"
     
     - name: Upload artifacts - macOS arm64
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR uses the script in `wargus/mac/bundle.sh` to make the basic app bundle. This removes a good few lines from the CI script, reducing code duplication. 

(I had also tried to move the dylibbundler and signing steps to the bundle script too but it didn't work, so leaving it in the CI script for now).