### PR TITLE
CI: Add x86 builds for macOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -88,65 +88,65 @@ jobs:
         if-no-files-found: error
 
   macOS-x86:
-  runs-on: macos-13
+    runs-on: macos-13
   
-  steps:
-  - name: Checkout Wargus
-    uses: actions/checkout@v4
-    with:
-      repository: Wargus/wargus
-      submodules: recursive
-      path: wargus
-      
-  - name: Checkout Stratagus
-    uses: actions/checkout@v4
-    with: 
-      repository: Wargus/stratagus
-      submodules: recursive
-      path: stratagus
-  
-  - name: Install dependencies
-    run: brew install dylibbundler sdl2 sdl2_mixer sdl2_image lua ffmpeg
-  
-  - name: cmake --version
-    run: cmake --version
-  
-  - name: Build Stratagus
-    run: |
-      cmake stratagus -B stratagus/build \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_FIND_FRAMEWORK=LAST \
-      -DBUILD_VENDORED_LUA=ON \
-      -DBUILD_VENDORED_SDL=OFF \
-      -DBUILD_VENDORED_MEDIA_LIBS=OFF \
-      -DBUILD_TESTING=1
-      cmake --build stratagus/build --config Release
-  
-  - name: Build Wargus
-    run: |
-      cmake wargus -B wargus/build \
-      -DCMAKE_FIND_FRAMEWORK=LAST \
-      -DSTRATAGUS_INCLUDE_DIR=../stratagus/gameheaders \
-      -DSTRATAGUS=../stratagus/build/stratagus 
-      cmake --build wargus/build --config Release
-  
-  - name: Create Wargus app bundle
-    run: |
-      export STRATAGUS_INCLUDE_DIR=stratagus/gameheaders
-      export STRATAGUS=stratagus/build/stratagus
-      wargus/mac/bundle.sh
-      
-      dylibbundler -of -cd -b -x wargus/mac/Wargus.app/Contents/MacOS/stratagus -d wargus/mac/Wargus.app/Contents/libs/
-      dylibbundler -of -cd -b -x wargus/mac/Wargus.app/Contents/MacOS/wartool -d wargus/mac/Wargus.app/Contents/libs/
-      
-      codesign --force --deep --sign - wargus/mac/Wargus.app
-      
-  - name: Create dmg
-    run: hdiutil create -volname "Wargus" -srcfolder "wargus/mac/Wargus.app" "Wargus-x86"
-  
-  - name: Upload artifacts - macOS x86
-    uses: actions/upload-artifact@v4
-    with:
-      name: Wargus-macOS-x86
-      path: Wargus-x86.dmg
-      if-no-files-found: error
+    steps:
+    - name: Checkout Wargus
+      uses: actions/checkout@v4
+      with:
+        repository: Wargus/wargus
+        submodules: recursive
+        path: wargus
+        
+    - name: Checkout Stratagus
+      uses: actions/checkout@v4
+      with: 
+        repository: Wargus/stratagus
+        submodules: recursive
+        path: stratagus
+    
+    - name: Install dependencies
+      run: brew install dylibbundler sdl2 sdl2_mixer sdl2_image lua ffmpeg
+    
+    - name: cmake --version
+      run: cmake --version
+    
+    - name: Build Stratagus
+      run: |
+        cmake stratagus -B stratagus/build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_FIND_FRAMEWORK=LAST \
+        -DBUILD_VENDORED_LUA=ON \
+        -DBUILD_VENDORED_SDL=OFF \
+        -DBUILD_VENDORED_MEDIA_LIBS=OFF \
+        -DBUILD_TESTING=1
+        cmake --build stratagus/build --config Release
+    
+    - name: Build Wargus
+      run: |
+        cmake wargus -B wargus/build \
+        -DCMAKE_FIND_FRAMEWORK=LAST \
+        -DSTRATAGUS_INCLUDE_DIR=../stratagus/gameheaders \
+        -DSTRATAGUS=../stratagus/build/stratagus 
+        cmake --build wargus/build --config Release
+    
+    - name: Create Wargus app bundle
+      run: |
+        export STRATAGUS_INCLUDE_DIR=stratagus/gameheaders
+        export STRATAGUS=stratagus/build/stratagus
+        wargus/mac/bundle.sh
+        
+        dylibbundler -of -cd -b -x wargus/mac/Wargus.app/Contents/MacOS/stratagus -d wargus/mac/Wargus.app/Contents/libs/
+        dylibbundler -of -cd -b -x wargus/mac/Wargus.app/Contents/MacOS/wartool -d wargus/mac/Wargus.app/Contents/libs/
+        
+        codesign --force --deep --sign - wargus/mac/Wargus.app
+        
+    - name: Create dmg
+      run: hdiutil create -volname "Wargus" -srcfolder "wargus/mac/Wargus.app" "Wargus-x86"
+    
+    - name: Upload artifacts - macOS x86
+      uses: actions/upload-artifact@v4
+      with:
+        name: Wargus-macOS-x86
+        path: Wargus-x86.dmg
+        if-no-files-found: error

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,4 @@
-name: macOS-arm64
+name: macOS
 
 on:
   workflow_dispatch:
@@ -23,7 +23,7 @@ on:
       - '!doc/**'
 
 jobs:
-  macos:
+  macOS-arm:
     runs-on: macos-latest
 
     steps:
@@ -86,3 +86,67 @@ jobs:
         name: Wargus-macOS-arm64
         path: Wargus-arm64.dmg
         if-no-files-found: error
+
+  macOS-x86:
+  runs-on: macos-13
+  
+  steps:
+  - name: Checkout Wargus
+    uses: actions/checkout@v4
+    with:
+      repository: Wargus/wargus
+      submodules: recursive
+      path: wargus
+      
+  - name: Checkout Stratagus
+    uses: actions/checkout@v4
+    with: 
+      repository: Wargus/stratagus
+      submodules: recursive
+      path: stratagus
+  
+  - name: Install dependencies
+    run: brew install dylibbundler sdl2 sdl2_mixer sdl2_image lua ffmpeg
+  
+  - name: cmake --version
+    run: cmake --version
+  
+  - name: Build Stratagus
+    run: |
+      cmake stratagus -B stratagus/build \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_FIND_FRAMEWORK=LAST \
+      -DBUILD_VENDORED_LUA=ON \
+      -DBUILD_VENDORED_SDL=OFF \
+      -DBUILD_VENDORED_MEDIA_LIBS=OFF \
+      -DBUILD_TESTING=1
+      cmake --build stratagus/build --config Release
+  
+  - name: Build Wargus
+    run: |
+      cmake wargus -B wargus/build \
+      -DCMAKE_FIND_FRAMEWORK=LAST \
+      -DSTRATAGUS_INCLUDE_DIR=../stratagus/gameheaders \
+      -DSTRATAGUS=../stratagus/build/stratagus 
+      cmake --build wargus/build --config Release
+  
+  - name: Create Wargus app bundle
+    run: |
+      export STRATAGUS_INCLUDE_DIR=stratagus/gameheaders
+      export STRATAGUS=stratagus/build/stratagus
+      wargus/mac/bundle.sh
+      
+      dylibbundler -of -cd -b -x wargus/mac/Wargus.app/Contents/MacOS/stratagus -d wargus/mac/Wargus.app/Contents/libs/
+      dylibbundler -of -cd -b -x wargus/mac/Wargus.app/Contents/MacOS/wartool -d wargus/mac/Wargus.app/Contents/libs/
+      
+      codesign --force --deep --sign - wargus/mac/Wargus.app
+      
+  - name: Create dmg
+    run: hdiutil create -volname "Wargus" -srcfolder "wargus/mac/Wargus.app" "Wargus-x86"
+  
+  - name: Upload artifacts - macOS x86
+    uses: actions/upload-artifact@v4
+    with:
+      name: Wargus-macOS-x86
+      path: Wargus-x86.dmg
+      if-no-files-found: error

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,8 +23,16 @@ on:
       - '!doc/**'
 
 jobs:
-  macOS-arm:
-    runs-on: macos-latest
+  macOS:
+    
+    strategy:
+      matrix:
+        include:
+            - runner: macos-latest
+              suffix: arm64
+            - runner: macos-13
+              suffix: x86
+    runs-on: ${{ matrix.runner}}
 
     steps:
     - name: Checkout Wargus
@@ -78,75 +86,11 @@ jobs:
         codesign --force --deep --sign - wargus/mac/Wargus.app
         
     - name: Create dmg
-      run: hdiutil create -volname "Wargus" -srcfolder "wargus/mac/Wargus.app" "Wargus-arm64"
+      run: hdiutil create -volname "Wargus" -srcfolder "wargus/mac/Wargus.app" "Wargus-${{ matrix.suffix }}"
     
-    - name: Upload artifacts - macOS arm64
+    - name: Upload artifacts - macOS ${{ matrix.suffix }}
       uses: actions/upload-artifact@v4
       with:
-        name: Wargus-macOS-arm64
-        path: Wargus-arm64.dmg
-        if-no-files-found: error
-
-  macOS-x86:
-    runs-on: macos-13
-  
-    steps:
-    - name: Checkout Wargus
-      uses: actions/checkout@v4
-      with:
-        repository: Wargus/wargus
-        submodules: recursive
-        path: wargus
-        
-    - name: Checkout Stratagus
-      uses: actions/checkout@v4
-      with: 
-        repository: Wargus/stratagus
-        submodules: recursive
-        path: stratagus
-    
-    - name: Install dependencies
-      run: brew install dylibbundler sdl2 sdl2_mixer sdl2_image lua ffmpeg
-    
-    - name: cmake --version
-      run: cmake --version
-    
-    - name: Build Stratagus
-      run: |
-        cmake stratagus -B stratagus/build \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_FIND_FRAMEWORK=LAST \
-        -DBUILD_VENDORED_LUA=ON \
-        -DBUILD_VENDORED_SDL=OFF \
-        -DBUILD_VENDORED_MEDIA_LIBS=OFF \
-        -DBUILD_TESTING=1
-        cmake --build stratagus/build --config Release
-    
-    - name: Build Wargus
-      run: |
-        cmake wargus -B wargus/build \
-        -DCMAKE_FIND_FRAMEWORK=LAST \
-        -DSTRATAGUS_INCLUDE_DIR=../stratagus/gameheaders \
-        -DSTRATAGUS=../stratagus/build/stratagus 
-        cmake --build wargus/build --config Release
-    
-    - name: Create Wargus app bundle
-      run: |
-        export STRATAGUS_INCLUDE_DIR=stratagus/gameheaders
-        export STRATAGUS=stratagus/build/stratagus
-        wargus/mac/bundle.sh
-        
-        dylibbundler -of -cd -b -x wargus/mac/Wargus.app/Contents/MacOS/stratagus -d wargus/mac/Wargus.app/Contents/libs/
-        dylibbundler -of -cd -b -x wargus/mac/Wargus.app/Contents/MacOS/wartool -d wargus/mac/Wargus.app/Contents/libs/
-        
-        codesign --force --deep --sign - wargus/mac/Wargus.app
-        
-    - name: Create dmg
-      run: hdiutil create -volname "Wargus" -srcfolder "wargus/mac/Wargus.app" "Wargus-x86"
-    
-    - name: Upload artifacts - macOS x86
-      uses: actions/upload-artifact@v4
-      with:
-        name: Wargus-macOS-x86
-        path: Wargus-x86.dmg
+        name: Wargus-macOS-${{ matrix.suffix }}
+        path: Wargus-${{ matrix.suffix }}.dmg
         if-no-files-found: error


### PR DESCRIPTION
This PR adds a new job that is almost identical to the arm one except that it builds using a macOS 13 runner. These are run on x86 Macs, so the output is an x86 build.

The macOS 13 runners will be deprecated eventually, so it will need to be modified to allow cross-compilation before then.