### PR TITLE
Bump x86 runner to macOS 15 Intel

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,7 +30,7 @@ jobs:
         include:
             - runner: macos-latest
               suffix: arm64
-            - runner: macos-13
+            - runner: macos-15-intel
               suffix: x86
     runs-on: ${{ matrix.runner}}
 


### PR DESCRIPTION
The x86 macOS 13 runner is going to be disabled soon.

This PR replaces it with the macOS 15 Intel runner.

