### PR TITLE
Apply StormLib big-endian build fixes to the vendored copy

### DIFF
--- a/StormLib/src/SBaseCommon.cpp
+++ b/StormLib/src/SBaseCommon.cpp
@@ -1915,7 +1915,7 @@ void ConvertTMPQHeader(void *header, uint16_t version)
 	TMPQHeader * theHeader = (TMPQHeader *)header;
 
     // Swap header part version 1
-    if(version == MPQ_FORMAT_VERSION_1)
+    if(version >= MPQ_FORMAT_VERSION_1)
     {
 	    theHeader->dwID = SwapUInt32(theHeader->dwID);
 	    theHeader->dwHeaderSize = SwapUInt32(theHeader->dwHeaderSize);
@@ -1928,21 +1928,21 @@ void ConvertTMPQHeader(void *header, uint16_t version)
 	    theHeader->dwBlockTableSize = SwapUInt32(theHeader->dwBlockTableSize);
     }
 
-	if(version == MPQ_FORMAT_VERSION_2)
+	if(version >= MPQ_FORMAT_VERSION_2)
 	{
 		theHeader->HiBlockTablePos64 = SwapUInt64(theHeader->HiBlockTablePos64);
         theHeader->wHashTablePosHi = SwapUInt16(theHeader->wHashTablePosHi);
 		theHeader->wBlockTablePosHi = SwapUInt16(theHeader->wBlockTablePosHi);
     }
 
-    if(version == MPQ_FORMAT_VERSION_3)
+    if(version >= MPQ_FORMAT_VERSION_3)
     {
         theHeader->ArchiveSize64 = SwapUInt64(theHeader->ArchiveSize64);
         theHeader->BetTablePos64 = SwapUInt64(theHeader->BetTablePos64);
         theHeader->HetTablePos64 = SwapUInt64(theHeader->HetTablePos64);
     }
 
-    if(version == MPQ_FORMAT_VERSION_4)
+    if(version >= MPQ_FORMAT_VERSION_4)
 	{
         theHeader->HashTableSize64    = SwapUInt64(theHeader->HashTableSize64);
         theHeader->BlockTableSize64   = SwapUInt64(theHeader->BlockTableSize64);

--- a/StormLib/src/SFileAttributes.cpp
+++ b/StormLib/src/SFileAttributes.cpp
@@ -180,7 +180,7 @@ static DWORD LoadAttributesFile(TMPQArchive * ha, LPBYTE pbAttrFile, DWORD cbAtt
         if((pbAttrPtr + cbArraySize) > pbAttrFileEnd)
             return ERROR_FILE_CORRUPT;
 
-        BSWAP_ARRAY32_UNSIGNED(ArrayCRC32, cbCRC32Size);
+        BSWAP_ARRAY32_UNSIGNED(ArrayCRC32, cbArraySize);
         for(i = 0; i < dwAttributesEntries; i++)
             ha->pFileTable[i].dwCrc32 = ArrayCRC32[i];
         pbAttrPtr += cbArraySize;
@@ -196,7 +196,7 @@ static DWORD LoadAttributesFile(TMPQArchive * ha, LPBYTE pbAttrFile, DWORD cbAtt
         if((pbAttrPtr + cbArraySize) > pbAttrFileEnd)
             return ERROR_FILE_CORRUPT;
 
-        BSWAP_ARRAY64_UNSIGNED(ArrayFileTime, cbFileTimeSize);
+        BSWAP_ARRAY64_UNSIGNED(ArrayFileTime, cbArraySize);
         for(i = 0; i < dwAttributesEntries; i++)
             ha->pFileTable[i].FileTime = ArrayFileTime[i];
         pbAttrPtr += cbArraySize;

--- a/StormLib/src/SFilePatchArchives.cpp
+++ b/StormLib/src/SFilePatchArchives.cpp
@@ -480,7 +480,7 @@ static bool IsMatchingPatchFile(
         {
             // Load the patch header
             SFileReadFile(hFile, &PatchHeader, sizeof(MPQ_PATCH_HEADER), &dwTransferred, NULL);
-            BSWAP_ARRAY32_UNSIGNED(pPatchHeader, sizeof(DWORD) * 6);
+            BSWAP_ARRAY32_UNSIGNED(&PatchHeader, sizeof(DWORD) * 6);
 
             // If the file contains an incremental patch,
             // compare the "MD5 before patching" with the base file MD5

--- a/StormLib/src/StormLib.h
+++ b/StormLib/src/StormLib.h
@@ -631,8 +631,8 @@ typedef struct _TMPQHash
 
 #else
 
-    BYTE   Platform;
     BYTE   Reserved;
+    BYTE   Platform;
     USHORT lcLocale;
 
 #endif


### PR DESCRIPTION
Fixes #518.

The bundled StormLib is missing the big-endian fixes from upstream StormLib commit [`d1b47ab`](https://github.com/ladislav-zezula/StormLib/commit/d1b47ab454e9f20589c6b47c78e5875e19888cdf), so the build fails on big-endian platforms such as macppc (the build log referenced in #518).

### Why it breaks the build
On big-endian the `BSWAP_ARRAY*` macros expand to real calls (they are no-ops on little-endian, which is why CI never caught it). Two of them reference symbols that do not exist in scope:
- `SFilePatchArchives.cpp`: `pPatchHeader` instead of `&PatchHeader`
- `SFileAttributes.cpp`: `cbCRC32Size` / `cbFileTimeSize` instead of `cbArraySize`

The patch also fixes two correctness issues in the same upstream commit: the version checks in `ConvertTMPQHeader` (`==` to `>=`, so higher MPQ format versions still get the lower-version byte swaps) and the `Platform`/`Reserved` field order in the big-endian branch of `TMPQHash`.

### Verification
I forced the big-endian path (`-D__BIG_ENDIAN__`) with a big-endian MIPS cross compiler. The three affected files fail to compile before this change (`'pPatchHeader' was not declared`, `'cbCRC32Size' was not declared`, `'cbFileTimeSize' was not declared`) and compile cleanly after. This is a straight application of the upstream StormLib fix to the vendored copy.